### PR TITLE
Simplify shell_execute flow and queued concurrency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ AWS CLI-style extensions:
 Examples:
 
 ```bash
-shell-server-cli --branch main tool shell-execute --input-json '{"command":"echo hello","execution_mode":"foreground"}'
+shell-server-cli --branch main tool shell-execute --input-json '{"command":"echo hello","foreground_wait_seconds":10}'
 shell-server-cli --branch main tool shell-execute --command "echo hello" --execution-mode foreground --query '.result.stdout'
 shell-server-cli --branch main tool server-reattach --server-id '<server-id>' --config-updates '{"enhanced_mode_enabled":false,"llm_evaluation_enabled":false}'
 ```
@@ -187,6 +187,7 @@ Detailed fixed procedure for automation/Copilot is documented in `.github/copilo
 - `SHELL_SERVER_DAEMON_SOCKET` (socket path override)
 - `SHELL_SERVER_DAEMON_CWD` (working directory override)
 - `SHELL_SERVER_DAEMON_BRANCH` (branch namespace override)
+- `SHELL_SERVER_MAX_CONCURRENT_PROCESSES` (max concurrent executions; default `8`)
 
 ## Evaluator Errors (HTTP Analogy)
 

--- a/src/backoffice/index.ts
+++ b/src/backoffice/index.ts
@@ -18,7 +18,7 @@ async function main() {
       logger.warn('Backoffice bootstrap: failed to load history', { error: String(e) }, 'backoffice');
     });
 
-    const processManager = new ProcessManager(50, '/tmp/mcp-shell-outputs', fileManager);
+    const processManager = new ProcessManager(8, '/tmp/mcp-shell-outputs', fileManager);
     const terminalManager = new TerminalManager();
     processManager.setTerminalManager(terminalManager);
 

--- a/src/core/process-manager.ts
+++ b/src/core/process-manager.ts
@@ -37,7 +37,7 @@ export interface ExecutionOptions {
   environmentVariables?: EnvironmentVariables;
   inputData?: string;
   inputOutputId?: string;
-  timeoutSeconds: number;
+  timeoutSeconds?: number;
   foregroundTimeoutSeconds?: number;
   maxOutputSize: number;
   captureStderr: boolean;
@@ -76,12 +76,94 @@ export class ProcessManager {
   private realtimeStreamSubscriber: RealtimeStreamSubscriber | undefined;
   private enableStreaming: boolean = false; // Feature Flag
 
+  private buildConcurrencyStopCandidates(limit = 5): Array<{
+    execution_id: string;
+    process_id?: number;
+    command: string;
+    runtime_seconds?: number;
+    status: string;
+    suggested_action: {
+      tool: 'process_kill';
+      parameters: {
+        process_id?: number;
+        signal: 'TERM';
+        force: false;
+      };
+    };
+  }> {
+    const now = Date.now();
+    return Array.from(this.executions.values())
+      .filter((exec) => exec.status === 'running')
+      .sort((a, b) => {
+        const aStart = a.started_at ? new Date(a.started_at).getTime() : Number.MAX_SAFE_INTEGER;
+        const bStart = b.started_at ? new Date(b.started_at).getTime() : Number.MAX_SAFE_INTEGER;
+        return aStart - bStart;
+      })
+      .slice(0, limit)
+      .map((exec) => {
+        const startedAtMs = exec.started_at ? new Date(exec.started_at).getTime() : undefined;
+        const runtimeSeconds = startedAtMs && Number.isFinite(startedAtMs)
+          ? Math.max(0, Math.floor((now - startedAtMs) / 1000))
+          : undefined;
+
+        return {
+          execution_id: exec.execution_id,
+          ...(exec.process_id !== undefined ? { process_id: exec.process_id } : {}),
+          command: exec.command.length > 120 ? `${exec.command.slice(0, 117)}...` : exec.command,
+          ...(runtimeSeconds !== undefined ? { runtime_seconds: runtimeSeconds } : {}),
+          status: exec.status,
+          suggested_action: {
+            tool: 'process_kill',
+            parameters: {
+              ...(exec.process_id !== undefined ? { process_id: exec.process_id } : {}),
+              signal: 'TERM',
+              force: false,
+            },
+          },
+        };
+      });
+  }
+  private getRunningExecutionCount(): number {
+    return Array.from(this.executions.values()).filter((exec) => exec.status === 'running').length;
+  }
+
+  private async waitForExecutionSlot(maxWaitMs: number, pollIntervalMs = 100): Promise<boolean> {
+    if (this.getRunningExecutionCount() < this.maxConcurrentProcesses) {
+      return true;
+    }
+
+    if (maxWaitMs <= 0) {
+      return false;
+    }
+
+    const deadline = Date.now() + maxWaitMs;
+    while (Date.now() < deadline) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, Math.min(pollIntervalMs, Math.max(1, deadline - Date.now())));
+      });
+
+      if (this.getRunningExecutionCount() < this.maxConcurrentProcesses) {
+        return true;
+      }
+    }
+
+    return this.getRunningExecutionCount() < this.maxConcurrentProcesses;
+  }
+
   constructor(
-    maxConcurrentProcesses = 50,
+    maxConcurrentProcesses = 8,
     outputDir = '/tmp/mcp-shell-outputs',
     fileManager?: FileManager
   ) {
-    this.maxConcurrentProcesses = maxConcurrentProcesses;
+    const envMaxConcurrentRaw = process.env['SHELL_SERVER_MAX_CONCURRENT_PROCESSES'];
+    const envMaxConcurrentParsed = envMaxConcurrentRaw
+      ? Number.parseInt(envMaxConcurrentRaw, 10)
+      : NaN;
+    const resolvedMaxConcurrent = Number.isFinite(envMaxConcurrentParsed) && envMaxConcurrentParsed > 0
+      ? envMaxConcurrentParsed
+      : maxConcurrentProcesses;
+
+    this.maxConcurrentProcesses = resolvedMaxConcurrent;
     this.outputDir = outputDir;
     this.fileManager = fileManager;
     this.defaultWorkingDirectory = process.env['SHELL_SERVER_DEFAULT_WORKDIR'] || process.cwd();
@@ -186,31 +268,71 @@ export class ProcessManager {
   }
 
   async executeCommand(options: ExecutionOptions): Promise<ExecutionInfo> {
-    // Check concurrent execution limit
-    const runningProcesses = Array.from(this.executions.values()).filter(
-      (exec) => exec.status === 'running'
-    ).length;
+    let effectiveOptions: ExecutionOptions = { ...options };
 
+    // For adaptive mode, when all slots are occupied, wait for a free slot
+    // using the same foreground wait budget requested by the caller.
+    const runningProcesses = this.getRunningExecutionCount();
     if (runningProcesses >= this.maxConcurrentProcesses) {
-      throw new ResourceLimitError('concurrent processes', this.maxConcurrentProcesses);
+      const queueWaitBudgetSeconds = effectiveOptions.executionMode === 'adaptive'
+        ? (effectiveOptions.foregroundTimeoutSeconds ?? 10)
+        : 0;
+      const queueWaitBudgetMs = Math.max(0, Math.floor(queueWaitBudgetSeconds * 1000));
+      const waitStartedAt = Date.now();
+      const acquired = await this.waitForExecutionSlot(queueWaitBudgetMs);
+      const waitedMs = Date.now() - waitStartedAt;
+
+      if (!acquired) {
+        const currentRunning = this.getRunningExecutionCount();
+        const stopCandidates = this.buildConcurrencyStopCandidates();
+        throw new ResourceLimitError(
+          'concurrent processes',
+          this.maxConcurrentProcesses,
+          undefined,
+          {
+            code: 'CONCURRENCY_LIMIT_EXCEEDED',
+            reason:
+              `Concurrent execution limit reached (${currentRunning}/${this.maxConcurrentProcesses}) and no slot became available within ${Math.floor(waitedMs / 1000)}s queue wait budget.`,
+            running_count: currentRunning,
+            limit: this.maxConcurrentProcesses,
+            queue_wait_budget_seconds: queueWaitBudgetSeconds,
+            waited_seconds: Math.floor(waitedMs / 1000),
+            stop_candidates: stopCandidates,
+            next_steps: [
+              'Call process_list with status_filter="running" to inspect active executions.',
+              'Stop one or more long-running commands via process_kill, then retry shell_execute.',
+            ],
+          }
+        );
+      }
+
+      if (effectiveOptions.executionMode === 'adaptive') {
+        const originalForegroundWaitSeconds = effectiveOptions.foregroundTimeoutSeconds ?? 10;
+        const remainingForegroundWaitSeconds = Math.max(
+          1,
+          Math.floor((originalForegroundWaitSeconds * 1000 - waitedMs) / 1000)
+        );
+        effectiveOptions = {
+          ...effectiveOptions,
+          foregroundTimeoutSeconds: remainingForegroundWaitSeconds,
+        };
+      }
     }
 
     // Prepare input data when input_output_id is specified
-    let resolvedInputData: string | undefined = options.inputData;
+    let resolvedInputData: string | undefined = effectiveOptions.inputData;
     let inputStream: StreamingPipelineReader | undefined = undefined;
 
-    if (options.inputOutputId) {
+    if (effectiveOptions.inputOutputId) {
       if (!this.fileManager) {
         throw new ExecutionError('FileManager is not available for input_output_id processing', {
-          inputOutputId: options.inputOutputId,
+          inputOutputId: effectiveOptions.inputOutputId,
         });
       }
 
-      // Identify execution ID from output_id
-      const sourceExecutionId = this.findExecutionIdByOutputId(options.inputOutputId);
+      const sourceExecutionId = this.findExecutionIdByOutputId(effectiveOptions.inputOutputId);
 
       if (sourceExecutionId && this.realtimeStreamSubscriber) {
-        // For active processes: use StreamingPipelineReader
         const streamState = this.realtimeStreamSubscriber.getStreamState(sourceExecutionId);
         if (streamState && streamState.isActive) {
           console.error(
@@ -219,28 +341,27 @@ export class ProcessManager {
           inputStream = new StreamingPipelineReader(
             this.fileManager,
             this.realtimeStreamSubscriber,
-            options.inputOutputId,
+            effectiveOptions.inputOutputId,
             sourceExecutionId
           );
         }
       }
 
-      // If not active (or on failure), fall back to traditional file read
       if (!inputStream) {
         try {
-          console.error(`ProcessManager: Using traditional file read for ${options.inputOutputId}`);
+          console.error(`ProcessManager: Using traditional file read for ${effectiveOptions.inputOutputId}`);
           const result = await this.fileManager.readFile(
-            options.inputOutputId,
+            effectiveOptions.inputOutputId,
             0,
-            100 * 1024 * 1024, // read up to 100MB
+            100 * 1024 * 1024,
             'utf-8'
           );
           resolvedInputData = result.content;
         } catch (error) {
           throw new ExecutionError(
-            `Failed to read input from output_id: ${options.inputOutputId}`,
+            `Failed to read input from output_id: ${effectiveOptions.inputOutputId}`,
             {
-              inputOutputId: options.inputOutputId,
+              inputOutputId: effectiveOptions.inputOutputId,
               originalError: String(error),
             }
           );
@@ -251,11 +372,10 @@ export class ProcessManager {
     const executionId = generateId();
     const startTime = getCurrentTimestamp();
 
-    // Initialize execution info
-    const resolvedWorkingDirectory = this.resolveWorkingDirectory(options.workingDirectory);
+    const resolvedWorkingDirectory = this.resolveWorkingDirectory(effectiveOptions.workingDirectory);
     const executionInfo: ExecutionInfo = {
       execution_id: executionId,
-      command: options.command,
+      command: effectiveOptions.command,
       status: 'running',
       working_directory: resolvedWorkingDirectory,
       default_working_directory: this.defaultWorkingDirectory,
@@ -264,35 +384,32 @@ export class ProcessManager {
       started_at: startTime,
     };
 
-    if (options.environmentVariables) {
-      executionInfo.environment_variables = options.environmentVariables;
+    if (effectiveOptions.environmentVariables) {
+      executionInfo.environment_variables = effectiveOptions.environmentVariables;
     }
 
     this.executions.set(executionId, executionInfo);
 
-    // If new terminal creation is requested
-    if (options.createTerminal && this.terminalManager) {
+    if (effectiveOptions.createTerminal && this.terminalManager) {
       try {
         const terminalOptions: TerminalOptions = {
           sessionName: `exec-${executionId}`,
-          shellType: (options.terminalShell as TerminalOptions['shellType']) || 'bash',
-          dimensions: options.terminalDimensions || { width: 80, height: 24 },
+          shellType: (effectiveOptions.terminalShell as TerminalOptions['shellType']) || 'bash',
+          dimensions: effectiveOptions.terminalDimensions || { width: 80, height: 24 },
           autoSaveHistory: true,
         };
-        if (options.workingDirectory) {
-          terminalOptions.workingDirectory = options.workingDirectory;
+        if (effectiveOptions.workingDirectory) {
+          terminalOptions.workingDirectory = effectiveOptions.workingDirectory;
         }
-        if (options.environmentVariables) {
-          terminalOptions.environmentVariables = options.environmentVariables;
+        if (effectiveOptions.environmentVariables) {
+          terminalOptions.environmentVariables = effectiveOptions.environmentVariables;
         }
 
         const terminalInfo = await this.terminalManager.createTerminal(terminalOptions);
         executionInfo.terminal_id = terminalInfo.terminal_id;
 
-        // Send command to terminal
-        this.terminalManager.sendInput(terminalInfo.terminal_id, options.command, true);
+        this.terminalManager.sendInput(terminalInfo.terminal_id, effectiveOptions.command, true);
 
-        // Update execution info
         executionInfo.status = 'completed';
         executionInfo.completed_at = getCurrentTimestamp();
         this.executions.set(executionId, executionInfo);
@@ -309,19 +426,17 @@ export class ProcessManager {
     }
 
     try {
-      // Prepare execution options
-      const { inputOutputId: _inputOutputId, ...baseOptions } = options;
+      const { inputOutputId: _inputOutputId, ...baseOptions } = effectiveOptions;
       const updatedOptions: ExecutionOptions = {
         ...baseOptions,
         ...(resolvedInputData !== undefined && { inputData: resolvedInputData }),
       };
 
-      // Special handling when StreamingPipelineReader exists
       if (inputStream) {
         return await this.executeCommandWithInputStream(executionId, updatedOptions, inputStream);
       }
 
-      switch (options.executionMode) {
+      switch (effectiveOptions.executionMode) {
         case 'foreground':
           return await this.executeForegroundCommand(executionId, updatedOptions);
         case 'adaptive':
@@ -331,10 +446,9 @@ export class ProcessManager {
         case 'detached':
           return await this.executeDetachedCommand(executionId, updatedOptions);
         default:
-          throw new ExecutionError('Unsupported execution mode', { mode: options.executionMode });
+          throw new ExecutionError('Unsupported execution mode', { mode: effectiveOptions.executionMode });
       }
     } catch (error) {
-      // Update execution info on error
       const updatedInfo = this.executions.get(executionId);
       if (updatedInfo) {
         updatedInfo.status = 'failed';
@@ -481,19 +595,23 @@ export class ProcessManager {
       });
 
       // Timeout handling
-      const timeout = setTimeout(() => {
-        console.error(`Process timeout for ${executionId}`);
-        child.kill('SIGTERM');
+      const timeout = options.timeoutSeconds !== undefined
+        ? setTimeout(() => {
+            console.error(`Process timeout for ${executionId}`);
+            child.kill('SIGTERM');
 
-        setTimeout(() => {
-          if (!child.killed) {
-            child.kill('SIGKILL');
-          }
-        }, 5000);
-      }, options.timeoutSeconds * 1000);
+            setTimeout(() => {
+              if (!child.killed) {
+                child.kill('SIGKILL');
+              }
+            }, 5000);
+          }, options.timeoutSeconds * 1000)
+        : undefined;
 
       child.on('close', () => {
-        clearTimeout(timeout);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
       });
     });
   }
@@ -526,54 +644,56 @@ export class ProcessManager {
       }
 
       // Set timeout
-      const timeout = setTimeout(async () => {
-        childProcess.kill('SIGTERM');
-        setTimeout(() => {
-          if (!childProcess.killed) {
-            childProcess.kill('SIGKILL');
-          }
-        }, 5000);
+      const timeout = options.timeoutSeconds !== undefined
+        ? setTimeout(async () => {
+            childProcess.kill('SIGTERM');
+            setTimeout(() => {
+              if (!childProcess.killed) {
+                childProcess.kill('SIGKILL');
+              }
+            }, 5000);
 
-        const executionTime = Date.now() - startTime;
-        const executionInfo = this.executions.get(executionId);
-        if (executionInfo) {
-          executionInfo.status = 'timeout';
-          executionInfo.stdout = sanitizeString(stdout);
-          executionInfo.stderr = sanitizeString(stderr);
-          executionInfo.completed_at = getCurrentTimestamp();
-          executionInfo.execution_time_ms = executionTime;
-          if (childProcess.pid !== undefined) {
-            executionInfo.process_id = childProcess.pid;
-          }
+            const executionTime = Date.now() - startTime;
+            const executionInfo = this.executions.get(executionId);
+            if (executionInfo) {
+              executionInfo.status = 'timeout';
+              executionInfo.stdout = sanitizeString(stdout);
+              executionInfo.stderr = sanitizeString(stderr);
+              executionInfo.completed_at = getCurrentTimestamp();
+              executionInfo.execution_time_ms = executionTime;
+              if (childProcess.pid !== undefined) {
+                executionInfo.process_id = childProcess.pid;
+              }
 
-          // Save output to FileManager (regardless of size)
-          let outputFileId: string | undefined;
-          try {
-            outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
-            executionInfo.output_id = outputFileId;
-          } catch (error) {
-            // Record file-save failures as critical errors and include them in execution info
-            console.error(
-              `[CRITICAL] Failed to save output file for execution ${executionId}:`,
-              error
-            );
-            executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
-          }
+              // Save output to FileManager (regardless of size)
+              let outputFileId: string | undefined;
+              try {
+                outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
+                executionInfo.output_id = outputFileId;
+              } catch (error) {
+                // Record file-save failures as critical errors and include them in execution info
+                console.error(
+                  `[CRITICAL] Failed to save output file for execution ${executionId}:`,
+                  error
+                );
+                executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
+              }
 
-          // Set detailed output status
-          this.setOutputStatus(executionInfo, outputTruncated, 'timeout', outputFileId);
+              // Set detailed output status
+              this.setOutputStatus(executionInfo, outputTruncated, 'timeout', outputFileId);
 
-          this.executions.set(executionId, executionInfo);
+              this.executions.set(executionId, executionInfo);
 
-          // Return partial result when return_partial_on_timeout is true
-          if (options.returnPartialOnTimeout) {
-            resolve(executionInfo);
-            return;
-          }
-        }
+              // Return partial result when return_partial_on_timeout is true
+              if (options.returnPartialOnTimeout) {
+                resolve(executionInfo);
+                return;
+              }
+            }
 
-        reject(new TimeoutError(options.timeoutSeconds));
-      }, options.timeoutSeconds * 1000);
+            reject(new TimeoutError(options.timeoutSeconds ?? 0));
+          }, options.timeoutSeconds * 1000)
+        : undefined;
 
       // Send stdin
       if (options.inputData) {
@@ -609,7 +729,9 @@ export class ProcessManager {
 
       // Handle process close
       childProcess.on('close', async (code) => {
-        clearTimeout(timeout);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
         if (childProcess.pid) {
           this.processes.delete(childProcess.pid);
         }
@@ -722,46 +844,48 @@ export class ProcessManager {
       }, foregroundTimeout * 1000);
 
       // Set final timeout
-      const finalTimeoutHandle = setTimeout(async () => {
-        childProcess.kill('SIGTERM');
-        setTimeout(() => {
-          if (!childProcess.killed) {
-            childProcess.kill('SIGKILL');
-          }
-        }, 5000);
+      const finalTimeoutHandle = options.timeoutSeconds !== undefined
+        ? setTimeout(async () => {
+            childProcess.kill('SIGTERM');
+            setTimeout(() => {
+              if (!childProcess.killed) {
+                childProcess.kill('SIGKILL');
+              }
+            }, 5000);
 
-        const executionInfo = this.executions.get(executionId);
-        if (executionInfo) {
-          executionInfo.status = 'timeout';
-          executionInfo.stdout = sanitizeString(stdout);
-          executionInfo.stderr = sanitizeString(stderr);
-          executionInfo.output_truncated = outputTruncated;
-          executionInfo.completed_at = getCurrentTimestamp();
-          executionInfo.execution_time_ms = Date.now() - startTime;
+            const executionInfo = this.executions.get(executionId);
+            if (executionInfo) {
+              executionInfo.status = 'timeout';
+              executionInfo.stdout = sanitizeString(stdout);
+              executionInfo.stderr = sanitizeString(stderr);
+              executionInfo.output_truncated = outputTruncated;
+              executionInfo.completed_at = getCurrentTimestamp();
+              executionInfo.execution_time_ms = Date.now() - startTime;
 
-          // Save output to FileManager
-          try {
-            const outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
-            executionInfo.output_id = outputFileId;
-          } catch (error) {
-            // Record file-save failures as critical errors and include them in execution info
-            console.error(
-              `[CRITICAL] Failed to save output file for execution ${executionId}:`,
-              error
-            );
-            executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
-          }
+              // Save output to FileManager
+              try {
+                const outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
+                executionInfo.output_id = outputFileId;
+              } catch (error) {
+                // Record file-save failures as critical errors and include them in execution info
+                console.error(
+                  `[CRITICAL] Failed to save output file for execution ${executionId}:`,
+                  error
+                );
+                executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
+              }
 
-          this.executions.set(executionId, executionInfo);
+              this.executions.set(executionId, executionInfo);
 
-          if (returnPartialOnTimeout) {
-            resolve(executionInfo);
-            return;
-          }
-        }
+              if (returnPartialOnTimeout) {
+                resolve(executionInfo);
+                return;
+              }
+            }
 
-        reject(new TimeoutError(options.timeoutSeconds));
-      }, options.timeoutSeconds * 1000);
+            reject(new TimeoutError(options.timeoutSeconds ?? 0));
+          }, options.timeoutSeconds * 1000)
+        : undefined;
 
       // Function to transition to background mode
       const transitionToBackground = async () => {
@@ -809,12 +933,14 @@ export class ProcessManager {
           this.executions.set(executionId, executionInfo);
 
           // Configure continued background handling (adaptive mode only)
+          const remainingTimeoutSeconds = options.timeoutSeconds !== undefined
+            ? Math.max(1, options.timeoutSeconds - Math.floor((Date.now() - startTime) / 1000))
+            : undefined;
           this.handleAdaptiveBackgroundTransition(executionId, childProcess, {
             ...options,
-            timeoutSeconds: Math.max(
-              1,
-              options.timeoutSeconds - Math.floor((Date.now() - startTime) / 1000)
-            ),
+            ...(remainingTimeoutSeconds !== undefined
+              ? { timeoutSeconds: remainingTimeoutSeconds }
+              : {}),
           });
 
           resolve(executionInfo);
@@ -868,7 +994,9 @@ export class ProcessManager {
       // Handle process close
       childProcess.on('close', async (code) => {
         clearTimeout(foregroundTimeoutHandle);
-        clearTimeout(finalTimeoutHandle);
+        if (finalTimeoutHandle) {
+          clearTimeout(finalTimeoutHandle);
+        }
         if (childProcess.pid) {
           this.processes.delete(childProcess.pid);
         }
@@ -912,7 +1040,9 @@ export class ProcessManager {
       // Error handling
       childProcess.on('error', (error) => {
         clearTimeout(foregroundTimeoutHandle);
-        clearTimeout(finalTimeoutHandle);
+        if (finalTimeoutHandle) {
+          clearTimeout(finalTimeoutHandle);
+        }
         if (childProcess.pid) {
           this.processes.delete(childProcess.pid);
         }
@@ -984,57 +1114,59 @@ export class ProcessManager {
     let stderr = '';
 
     // Set timeout (for background processes)
-    const timeout = setTimeout(async () => {
-      childProcess.kill('SIGTERM');
-      setTimeout(() => {
-        if (!childProcess.killed) {
-          childProcess.kill('SIGKILL');
-        }
-      }, 5000);
-
-      const executionInfo = this.executions.get(executionId);
-      if (executionInfo) {
-        executionInfo.status = 'timeout';
-        executionInfo.stdout = stdout;
-        executionInfo.stderr = stderr;
-        executionInfo.output_truncated = true;
-        executionInfo.completed_at = getCurrentTimestamp();
-        executionInfo.execution_time_ms = Date.now() - startTime;
-
-        // Save output to FileManager
-        try {
-          const outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
-          executionInfo.output_id = outputFileId;
-        } catch (error) {
-          // Record file-save failures as critical errors and include them in execution info
-          console.error(
-            `[CRITICAL] Failed to save output file for execution ${executionId}:`,
-            error
-          );
-          executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
-        }
-
-        this.executions.set(executionId, executionInfo);
-
-        // Invoke timeout callback for background process
-        if (this.backgroundProcessCallbacks.onTimeout) {
-          setImmediate(async () => {
-            try {
-              const callback = this.backgroundProcessCallbacks.onTimeout;
-              if (callback) {
-                const result = callback(executionId, executionInfo);
-                if (result instanceof Promise) {
-                  await result;
-                }
-              }
-            } catch (callbackError) {
-              // Record callback errors in internal logs only
-              // console.error('Background process timeout callback error:', callbackError);
+    const timeout = options.timeoutSeconds !== undefined
+      ? setTimeout(async () => {
+          childProcess.kill('SIGTERM');
+          setTimeout(() => {
+            if (!childProcess.killed) {
+              childProcess.kill('SIGKILL');
             }
-          });
-        }
-      }
-    }, options.timeoutSeconds * 1000);
+          }, 5000);
+
+          const executionInfo = this.executions.get(executionId);
+          if (executionInfo) {
+            executionInfo.status = 'timeout';
+            executionInfo.stdout = stdout;
+            executionInfo.stderr = stderr;
+            executionInfo.output_truncated = true;
+            executionInfo.completed_at = getCurrentTimestamp();
+            executionInfo.execution_time_ms = Date.now() - startTime;
+
+            // Save output to FileManager
+            try {
+              const outputFileId = await this.saveOutputToFile(executionId, stdout, stderr);
+              executionInfo.output_id = outputFileId;
+            } catch (error) {
+              // Record file-save failures as critical errors and include them in execution info
+              console.error(
+                `[CRITICAL] Failed to save output file for execution ${executionId}:`,
+                error
+              );
+              executionInfo.message = `Output file save failed: ${error instanceof Error ? error.message : String(error)}`;
+            }
+
+            this.executions.set(executionId, executionInfo);
+
+            // Invoke timeout callback for background process
+            if (this.backgroundProcessCallbacks.onTimeout) {
+              setImmediate(async () => {
+                try {
+                  const callback = this.backgroundProcessCallbacks.onTimeout;
+                  if (callback) {
+                    const result = callback(executionId, executionInfo);
+                    if (result instanceof Promise) {
+                      await result;
+                    }
+                  }
+                } catch (callbackError) {
+                  // Record callback errors in internal logs only
+                  // console.error('Background process timeout callback error:', callbackError);
+                }
+              });
+            }
+          }
+        }, options.timeoutSeconds * 1000)
+      : undefined;
 
     // Collect output
     childProcess.stdout?.on('data', (data: Buffer) => {
@@ -1049,7 +1181,9 @@ export class ProcessManager {
 
     // Handle process close
     childProcess.on('close', async (code) => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       if (childProcess.pid) {
         this.processes.delete(childProcess.pid);
       }
@@ -1097,7 +1231,9 @@ export class ProcessManager {
     });
 
     childProcess.on('error', (error) => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       if (childProcess.pid) {
         this.processes.delete(childProcess.pid);
       }
@@ -1136,27 +1272,31 @@ export class ProcessManager {
     options: ExecutionOptions
   ): void {
     // Set timeout (final timeout)
-    const timeout = setTimeout(async () => {
-      childProcess.kill('SIGTERM');
-      setTimeout(() => {
-        if (!childProcess.killed) {
-          childProcess.kill('SIGKILL');
-        }
-      }, 5000);
+    const timeout = options.timeoutSeconds !== undefined
+      ? setTimeout(async () => {
+          childProcess.kill('SIGTERM');
+          setTimeout(() => {
+            if (!childProcess.killed) {
+              childProcess.kill('SIGKILL');
+            }
+          }, 5000);
 
-      const executionInfo = this.executions.get(executionId);
-      if (executionInfo) {
-        executionInfo.status = 'timeout';
-        executionInfo.completed_at = getCurrentTimestamp();
+          const executionInfo = this.executions.get(executionId);
+          if (executionInfo) {
+            executionInfo.status = 'timeout';
+            executionInfo.completed_at = getCurrentTimestamp();
 
-        // Keep existing output (already captured in adaptive mode)
-        this.executions.set(executionId, executionInfo);
-      }
-    }, options.timeoutSeconds * 1000);
+            // Keep existing output (already captured in adaptive mode)
+            this.executions.set(executionId, executionInfo);
+          }
+        }, options.timeoutSeconds * 1000)
+      : undefined;
 
     // Handle process close
     childProcess.on('close', async (code) => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       if (childProcess.pid) {
         this.processes.delete(childProcess.pid);
       }
@@ -1196,7 +1336,9 @@ export class ProcessManager {
     });
 
     childProcess.on('error', (error) => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       if (childProcess.pid) {
         this.processes.delete(childProcess.pid);
       }

--- a/src/runtime/tool-runtime.ts
+++ b/src/runtime/tool-runtime.ts
@@ -199,7 +199,7 @@ export function createShellToolRuntime(options: ShellToolRuntimeOptions = {}): S
   const fileManager = new FileManager();
   const configManager = new ConfigManager();
   const processManager = new ProcessManager(
-    options.maxConcurrentProcesses ?? 50,
+    options.maxConcurrentProcesses ?? 8,
     options.outputDir ?? '/tmp/mcp-shell-outputs',
     fileManager
   );

--- a/src/tools/shell-tools.ts
+++ b/src/tools/shell-tools.ts
@@ -181,29 +181,35 @@ export class ShellTools {
 
       // Traditional security checks (still performed)
       this.securityManager.auditCommand(params.command, params.working_directory);
-      this.securityManager.validateExecutionTime(params.timeout_seconds);
 
-      // Check max value for foreground_timeout_seconds
-      if (
-        params.execution_mode === 'foreground' &&
-        typeof params.foreground_timeout_seconds === 'number' &&
-        params.foreground_timeout_seconds > 300
-      ) {
-        throw new MCPShellError(
-          'TIMEOUT_LIMIT_EXCEEDED',
-          `foreground_timeout_seconds (${params.foreground_timeout_seconds}) exceeds the maximum allowed (300 seconds). For timeouts above 300 seconds, use execution_mode 'background' or 'adaptive'.`,
-          'PARAM'
-        );
+      const restrictions = this.securityManager.getRestrictions();
+      const policyTimeoutSeconds = restrictions?.active
+        ? restrictions.max_execution_time
+        : undefined;
+      const requestedTimeoutSeconds = params.execution_timeout_seconds ?? undefined;
+
+      if (requestedTimeoutSeconds !== undefined) {
+        this.securityManager.validateExecutionTime(requestedTimeoutSeconds);
       }
+
+      // Effective timeout: request timeout if provided, additionally capped by policy timeout.
+      const effectiveTimeoutSeconds = requestedTimeoutSeconds !== undefined
+        ? (policyTimeoutSeconds !== undefined
+            ? Math.min(requestedTimeoutSeconds, policyTimeoutSeconds)
+            : requestedTimeoutSeconds)
+        : policyTimeoutSeconds;
 
       const executionOptions: ExecutionOptions = {
         command: params.command,
-        executionMode: params.execution_mode,
-        timeoutSeconds: params.timeout_seconds,
-        foregroundTimeoutSeconds: params.foreground_timeout_seconds,
+        // Keep process-manager internals on adaptive flow while external API is simplified.
+        executionMode: 'adaptive',
+        foregroundTimeoutSeconds: params.foreground_wait_seconds,
         maxOutputSize: params.max_output_size,
         captureStderr: params.capture_stderr,
         returnPartialOnTimeout: params.return_partial_on_timeout,
+        ...(effectiveTimeoutSeconds !== undefined
+          ? { timeoutSeconds: effectiveTimeoutSeconds }
+          : {}),
       };
 
       // Add optional properties (only if not undefined)
@@ -249,10 +255,12 @@ export class ShellTools {
         const remote = new RemoteProcessService();
         const req: import('../core/remote-process-service.js').RemoteExecStartRequest = {
           command: executionOptions.command,
-          timeout_seconds: executionOptions.timeoutSeconds,
           capture_stderr: executionOptions.captureStderr,
           max_output_size: executionOptions.maxOutputSize,
         };
+        if (executionOptions.timeoutSeconds !== undefined) {
+          req.timeout_seconds = executionOptions.timeoutSeconds;
+        }
         if (executionOptions.workingDirectory !== undefined) {
           req.working_directory = executionOptions.workingDirectory;
         }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  ExecutionModeSchema,
   ShellTypeSchema,
   ProcessSignalSchema,
   OutputTypeSchema,
@@ -24,9 +23,15 @@ export const ShellExecuteParamsSchema = z
       .describe(
         'Optional comment from the LLM client explaining the intent or context behind this command execution. This helps the safety evaluator understand the broader context, but will be treated as advisory only and not blindly trusted.'
       ),
-    execution_mode: ExecutionModeSchema.default('adaptive').describe(
-      'How the command should be executed: "foreground" (wait for completion), "background" (run async), "detached" (fire-and-forget), "adaptive" (start foreground, switch to background for long-running commands)'
-    ),
+    foreground_wait_seconds: z
+      .number()
+      .int()
+      .min(1)
+      .max(300)
+      .default(10)
+      .describe(
+        'Foreground wait window (1-300s). The server waits this long for completion, then returns running status if the command is still active.'
+      ),
     working_directory: z
       .string()
       .optional()
@@ -48,33 +53,15 @@ export const ShellExecuteParamsSchema = z
       .describe(
         'Output ID from previous command execution to use as input. Alternative to input_data for pipeline operations.'
       ),
-    timeout_seconds: z
+    execution_timeout_seconds: z
       .number()
       .int()
       .min(1)
       .max(3600)
-      .default(60)
+      .nullable()
+      .optional()
       .describe(
-        'Global timeout (1-3600s). Default: 60s.\n'
-        + 'Per execution_mode (effective limits before execution starts):\n'
-        + '• foreground: Schema allows 1-3600s, but the default security policy caps runs at 300s. Setting timeout_seconds above 300s raises TIMEOUT_LIMIT_EXCEEDED unless max_execution_time is increased via security_set_restrictions.\n'
-        + '• background: 1-3600s. Intended for >300s runs; still subject to the same security cap (300s by default) unless raised.\n'
-        + '• detached: 1-3600s. Shares the security cap behavior with background.\n'
-        + '• adaptive: 1-3600s total cap. The initial foreground phase also respects foreground_timeout_seconds (≤300s) and the security cap.\n'
-        + 'Guidance: For long-running tasks (>300s), raise max_execution_time or use background/adaptive modes.'
-      ),
-    foreground_timeout_seconds: z
-      .number()
-      .int()
-      .min(1)
-      .max(300)
-      .default(15)
-      .describe(
-        'Initial foreground window for adaptive mode (1-300s).\n'
-        + 'Behavior by execution_mode:\n'
-        + '• adaptive: Duration to remain in foreground before automatically switching to background if the command is still running. Must be ≤ timeout_seconds.\n'
-        + '• foreground: Does not trigger background switching (value is effectively unused for switching). Use background/adaptive for >300s scenarios.\n'
-        + '• background/detached: Ignored.'
+        'Optional hard timeout (1-3600s). If omitted or null, request-level timeout is disabled and only policy-level limits apply.'
       ),
     return_partial_on_timeout: z
       .boolean()
@@ -123,14 +110,6 @@ export const ShellExecuteParamsSchema = z
       ),
   })
   .strict()
-  // Cross-field validations for timeout relationships
-  .refine(
-    (data) => data.execution_mode !== 'adaptive' || (data.foreground_timeout_seconds ?? 15) <= (data.timeout_seconds ?? 60),
-    {
-      message: 'foreground_timeout_seconds must be less than or equal to timeout_seconds in adaptive mode.',
-      path: ['foreground_timeout_seconds'],
-    }
-  )
   .refine((data) => !(data.input_data && data.input_output_id), {
     message: 'input_data and input_output_id cannot be specified simultaneously.',
     path: ['input_data', 'input_output_id'],

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -105,12 +105,17 @@ export class SecurityError extends ShellServerError {
 }
 
 export class ResourceLimitError extends ShellServerError {
-  constructor(resource: string, limit: number, requestId?: string) {
+  constructor(
+    resource: string,
+    limit: number,
+    requestId?: string,
+    details?: Record<string, unknown>
+  ) {
     super(
       'RESOURCE_005',
       `${resource} limit of ${limit} reached`,
       'RESOURCE',
-      { resource, limit },
+      { resource, limit, ...(details ?? {}) },
       requestId
     );
   }

--- a/test/e2e-shell-server-cli.test.mjs
+++ b/test/e2e-shell-server-cli.test.mjs
@@ -86,7 +86,7 @@ test('shell-server-cli E2E: daemon + tool + query + help', async (t) => {
     'tool',
     'shell-execute',
     '--input-json',
-    '{"command":"echo e2e-json","execution_mode":"foreground"}',
+    '{"command":"echo e2e-json","foreground_wait_seconds":10}',
     '--query',
     '.result.stdout',
   ]);

--- a/test/process-manager.concurrency-limit.test.mjs
+++ b/test/process-manager.concurrency-limit.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { ProcessManager } from '../dist/core/process-manager.js';
+
+test('adaptive execution waits for a free slot within foreground wait budget', async () => {
+  const outputDir = path.join(os.tmpdir(), `mcp-shell-outputs-${randomUUID()}`);
+  const manager = new ProcessManager(1, outputDir);
+
+  const first = await manager.executeCommand({
+    command: 'sleep 1',
+    executionMode: 'background',
+    timeoutSeconds: 30,
+    maxOutputSize: 1024 * 1024,
+    captureStderr: true,
+    returnPartialOnTimeout: true,
+  });
+
+  assert.equal(first.status, 'running');
+
+  const startedAt = Date.now();
+  const second = await manager.executeCommand({
+    command: 'echo second',
+    executionMode: 'adaptive',
+    foregroundTimeoutSeconds: 3,
+    timeoutSeconds: 30,
+    maxOutputSize: 1024 * 1024,
+    captureStderr: true,
+    returnPartialOnTimeout: true,
+  });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(second.status, 'completed');
+  assert.match(second.stdout ?? '', /second/);
+  assert.equal(elapsedMs >= 800, true);
+
+  manager.cleanup();
+});
+
+test('adaptive execution returns English diagnostics when queue wait budget is exhausted', async () => {
+  const outputDir = path.join(os.tmpdir(), `mcp-shell-outputs-${randomUUID()}`);
+  const manager = new ProcessManager(1, outputDir);
+
+  const first = await manager.executeCommand({
+    command: 'sleep 2',
+    executionMode: 'background',
+    timeoutSeconds: 30,
+    maxOutputSize: 1024 * 1024,
+    captureStderr: true,
+    returnPartialOnTimeout: true,
+  });
+
+  assert.equal(first.status, 'running');
+
+  await assert.rejects(
+    async () => {
+      await manager.executeCommand({
+        command: 'echo second',
+        executionMode: 'adaptive',
+        foregroundTimeoutSeconds: 1,
+        timeoutSeconds: 30,
+        maxOutputSize: 1024 * 1024,
+        captureStderr: true,
+        returnPartialOnTimeout: true,
+      });
+    },
+    (error) => {
+      assert.equal(error?.code, 'RESOURCE_005');
+      assert.equal(error?.category, 'RESOURCE');
+
+      const details = error?.details ?? {};
+      assert.equal(details.code, 'CONCURRENCY_LIMIT_EXCEEDED');
+      assert.equal(typeof details.reason, 'string');
+      assert.match(details.reason, /Concurrent execution limit reached/);
+      assert.equal(details.limit, 1);
+      assert.equal(details.running_count, 1);
+      assert.equal(Array.isArray(details.stop_candidates), true);
+      assert.equal(details.stop_candidates.length > 0, true);
+      assert.equal(Array.isArray(details.next_steps), true);
+      return true;
+    }
+  );
+
+  manager.cleanup();
+});


### PR DESCRIPTION
## Summary
This PR simplifies shell execution behavior for LLM clients and improves concurrency handling.

## Related Issues
- Closes #8
- Closes #9
- Closes #10
- Closes #11

## Changes
- Remove `execution_mode` from external shell_execute schema.
- Add `foreground_wait_seconds` (default: 10).
- Add optional `execution_timeout_seconds` (nullable/optional).
- Internally unify to adaptive flow while preserving behavior compatibility.
- Set default max concurrent processes to 8 (with `SHELL_SERVER_MAX_CONCURRENT_PROCESSES` override).
- When concurrency is full, adaptive executions wait for a free slot within foreground wait budget.
- Return English actionable diagnostics if queue wait budget is exhausted.
- Add concurrency regression tests and update E2E/docs.

## Validation
- `npm run build`
- `node --test test/*.mjs`
- All tests passed.
